### PR TITLE
Allow using the STT for voice activity detection

### DIFF
--- a/.changeset/large-impalas-serve.md
+++ b/.changeset/large-impalas-serve.md
@@ -1,0 +1,5 @@
+---
+"livekit-agents": patch
+---
+
+Make VAD optional for agents that use streaming STT


### PR DESCRIPTION
This makes using the VAD optional - I believe this fixes some race conditions where STT and the VAD would disagree. It also reduces CPU usage a ton if you don't use silero.